### PR TITLE
Moving boilerplate images to cafinternal/

### DIFF
--- a/boilerplate-api-container/pom.xml
+++ b/boilerplate-api-container/pom.xml
@@ -264,7 +264,7 @@
 
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-integrationtests-postgres</link>

--- a/boilerplate-api-web/boilerplate-api-web/pom.xml
+++ b/boilerplate-api-web/boilerplate-api-web/pom.xml
@@ -330,7 +330,7 @@
 
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-integrationtests-postgres</link>

--- a/boilerplate-api/pom.xml
+++ b/boilerplate-api/pom.xml
@@ -247,7 +247,7 @@
 
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-integrationtests-postgres</link>

--- a/boilerplate-creation-container/pom.xml
+++ b/boilerplate-creation-container/pom.xml
@@ -78,7 +78,7 @@
                         <!-- Begin Boilerplate Creation image -->
                         <image>
                             <alias>boilerplate-creation-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-creator:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-creator-${project.version}</name>
                             <build>
                                 <from>java:8</from>
                                 <labels>

--- a/boilerplate-db-container/pom.xml
+++ b/boilerplate-db-container/pom.xml
@@ -78,7 +78,7 @@
                     <images>
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <build>
                                 <from>java:8</from>
                                 <maintainer>dominic.joh.gibson@hpe.com</maintainer>

--- a/worker-boilerplate-container-fs/pom.xml
+++ b/worker-boilerplate-container-fs/pom.xml
@@ -487,7 +487,7 @@
                         <!-- Begin Boilerplate db install image -->
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-integrationtests-postgres</link>

--- a/worker-boilerplate-container-fs/pom.xml
+++ b/worker-boilerplate-container-fs/pom.xml
@@ -566,7 +566,7 @@
                         <!-- Begin Boilerplate Creation image -->
                         <image>
                             <alias>boilerplate-creation-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-creator:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-creator-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-api</link>

--- a/worker-boilerplate/pom.xml
+++ b/worker-boilerplate/pom.xml
@@ -324,7 +324,7 @@
 
                         <image>
                             <alias>boilerplate-liquibase-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/boilerplate-db-installer:${project.version}</name>
+                            <name>cafinternal/prereleases:boilerplate-db-installer-${project.version}</name>
                             <run>
                                 <links>
                                     <link>boilerplate-integrationtests-postgres</link>


### PR DESCRIPTION
* Updated boilerplate-container image names from rh7 to cafinternal/prereleases:boilerplate-creator-${project.version}
* Updated boilerplate-db-installer image names from rh7 to cafinternal/prereleases:boilerplate-db-installer-${project.version} 


As per the email between Andy, Dermot and Michael

> I created a prereleases repository in cafinternal:
> https://hub.docker.com/r/cafinternal/prereleases/tags/
> 
> Just move to using that – so in this case:
> cafinternal/prereleases:boilerplate-creator-${project.version}
> 
> 
>
> From: Reid, Andy 
> Sent: 25 May 2017 10:00 AM
> To: Rogan, Adam Pau <adam.pau.rogan@hpe.com>
> Cc: Hardy, Dermot <dermot.hardy@hpe.com>; McAlynn, Michael <michael.mcalynn@hpe.com>
> Subject: Closed source dependencies
> 
> HI Adam,
> 
>                 Michael McAlynn discovered this one, could you create a ticket if needed?
> 
> 
> FYI Boilerplate creation image in the open source repo is being pushed to rh7 instead of cafdataprocessing;
> https://github.com/CAFDataProcessing/boilerplate-service/blob/develop/boilerplate-creation-container/pom.xml#L81 
> - Doesn't impact data processing open sourcing as it is being used in the internal data processing worker repository so it's fine to refer to rh7.
> 