### PR TITLE
CAF-3295: Add support to boilerplate creation util to remove existing…

### DIFF
--- a/release-notes-2.2.0.md
+++ b/release-notes-2.2.0.md
@@ -5,4 +5,9 @@ ${version-number}
 
 #### New Features
 
+- [CAF-3295](https://jira.autonomy.com/browse/CAF-3295): Add ability to remove existing expressions/tags that match input data during creation of boilerplate expressions and tags.
+    The boilerplate creation utility has also been updated to use slf4j log library.
+    Containers updated to support auto-release.
+
+
 #### Known Issues

--- a/util-boilerplate-creation/README.md
+++ b/util-boilerplate-creation/README.md
@@ -8,6 +8,8 @@ This utility allows for the bulk creation of boilerplate expressions and tags.
 2) Sends these to boilerplate-web-api (specified via environment variable) create method url.
 3) Outputs id's and names of created expressions and tags.
 
+By default if expressions/tags exist with the same name as those passed in to create then the existing expressions/tags will be deleted before the current set are created.
+
 ## Usage
 
 ### Prerequisites

--- a/util-boilerplate-creation/pom.xml
+++ b/util-boilerplate-creation/pom.xml
@@ -65,12 +65,14 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <!--Required at runtime for log4j output-->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <!--ADAPTER (not bridge) that allows slf4j api to route to the log4j implm-->
@@ -172,7 +174,7 @@
                         <!-- Begin Boilerplate Database image -->
                         <image>
                             <alias>boilerplate-integrationtests-postgres</alias>
-                            <name>index.docker.io/postgres:9.4</name>
+                            <name>postgres:9.4</name>
                             <run>
                                 <ports>
                                     <port>${cafPostgresDbPort}:5432</port>

--- a/util-boilerplate-creation/pom.xml
+++ b/util-boilerplate-creation/pom.xml
@@ -26,9 +26,14 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>com.github.cafdataprocessing</groupId>
     <artifactId>util-boilerplate-creation</artifactId>
+
+    <properties>
+        <cafBoilerplateDbName>boilerplate</cafBoilerplateDbName>
+        <cafBoilerplateDbPass>root</cafBoilerplateDbPass>
+        <cafBoilerplateDbUser>postgres</cafBoilerplateDbUser>
+        <cafBoilerplateApiUrl>http://${docker.host.address}:${cafBoilerplateAdminPort}/boilerplateapi</cafBoilerplateApiUrl>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -48,15 +53,46 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
-                <!--<exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>jsr311-api</artifactId>
-                </exclusion>-->
             </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <!--Required at runtime for log4j output-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <!--Required at runtime for log4j output-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <!--ADAPTER (not bridge) that allows slf4j api to route to the log4j implm-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.0-rc2</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -84,7 +120,218 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- plugins to enable integration testing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resources.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testResources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.failsafe.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- boilerplate setup specific properties -->
+                        <boilerplateapi.url>${cafBoilerplateApiUrl}</boilerplateapi.url>
+                        <docker.host.address>${docker.host.address}</docker.host.address>
+                        <postgres.db.port>${cafPostgresDbPort}</postgres.db.port>
+                    </systemPropertyVariables>
+                    <!--<debugForkedProcess>true</debugForkedProcess>-->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${fabric8.docker.maven.version}</version>
+                <configuration>
+                    <verbose>true</verbose>
+                    <autoPull>true</autoPull>
+                    <logDate>default</logDate>
+                    <images>
+                        <!-- Begin Boilerplate Database image -->
+                        <image>
+                            <alias>boilerplate-integrationtests-postgres</alias>
+                            <name>index.docker.io/postgres:9.4</name>
+                            <run>
+                                <ports>
+                                    <port>${cafPostgresDbPort}:5432</port>
+                                </ports>
+                                <env>
+                                    <POSTGRES_DB>${cafBoilerplateDbName}</POSTGRES_DB>
+                                    <POSTGRES_PASSWORD>${cafBoilerplateDbPass}</POSTGRES_PASSWORD>
+                                    <POSTGRES_USER>${cafBoilerplateDbUser}</POSTGRES_USER>
+                                </env>
+                                <wait>
+                                    <log>PostgreSQL init process complete</log>
+                                    <time>50000</time>
+                                    <shutdown>500</shutdown>
+                                </wait>
+                                <log>
+                                    <enabled>true</enabled>
+                                </log>
+                            </run>
+                        </image>
+                        <!-- End Boilerplate Database image -->
+
+                        <!-- Begin Boilerplate db install image -->
+                        <image>
+                            <alias>boilerplate-liquibase-container</alias>
+                            <name>${cafBoilerplateDbInstallerContainerName}</name>
+                            <run>
+                                <links>
+                                    <link>boilerplate-integrationtests-postgres</link>
+                                </links>
+                                <log>
+                                    <enabled>true</enabled>
+                                </log>
+                                <cmd>java -jar /boilerplate-db.jar -fd -db.user ${cafBoilerplateDbUser} -db.pass ${cafBoilerplateDbPass} -db.name ${cafBoilerplateDbName} -db.connection jdbc:postgresql://boilerplate-integrationtests-postgres:5432 -log debug
+                                </cmd>
+                                <wait>
+                                    <log>DB update finished.</log>
+                                    <time>60000</time>
+                                    <shutdown>500</shutdown>
+                                </wait>
+                            </run>
+                        </image>
+                        <!-- End Boilerplate db install image -->
+
+                        <!-- Begin Boilerplate API image -->
+                        <image>
+                            <alias>boilerplate-api</alias>
+                            <name>${cafBoilerplateApiContainerName}</name>
+                            <run>
+                                <ports>
+                                    <port>${cafBoilerplateAdminPort}:8080</port>
+                                </ports>
+                                <env>
+                                    <hibernate.connectionstring>
+                                        jdbc:postgresql://boilerplate-integrationtests-postgres:5432/${cafBoilerplateDbName}
+                                    </hibernate.connectionstring>
+                                    <hibernate.user>${cafBoilerplateDbUser}</hibernate.user>
+                                    <hibernate.password>${cafBoilerplateDbPass}</hibernate.password>
+                                </env>
+                                <links>
+                                    <link>boilerplate-integrationtests-postgres</link>
+                                </links>
+                                <log>
+                                    <enabled>true</enabled>
+                                </log>
+                                <wait>
+                                    <http>
+                                        <url>
+                                            http://${docker.host.address}:${cafBoilerplateAdminPort}/boilerplateapi/boilerplate/checkhealth?project_id=1
+                                        </url>
+                                    </http>
+                                    <time>50000</time>
+                                    <shutdown>500</shutdown>
+                                </wait>
+                            </run>
+                        </image>
+                        <!-- End Boilerplate API image -->
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>integration-test</id>
+            <activation>
+                <property>
+                    <name>RE_BUILD_TYPE</name>
+                    <value>continuous</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>${fabric8.docker.maven.version}</version>
+                        <executions>
+                            <execution>
+                                <id>start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>nightly-test</id>
+            <activation>
+                <property>
+                    <name>RE_BUILD_TYPE</name>
+                    <value>release</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>${fabric8.docker.maven.version}</version>
+                        <executions>
+                            <execution>
+                                <id>start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>use-default-fixed-ports</id>
+            <properties>
+                <cafBoilerplateAdminPort>5555</cafBoilerplateAdminPort>
+                <cafPostgresDbPort>5432</cafPostgresDbPort>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/util-boilerplate-creation/src/main/java/com/hpe/caf/util/boilerplate/creation/BoilerplateRemover.java
+++ b/util-boilerplate-creation/src/main/java/com/hpe/caf/util/boilerplate/creation/BoilerplateRemover.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.util.boilerplate.creation;
+
+import com.hpe.caf.boilerplate.webcaller.ApiException;
+import com.hpe.caf.boilerplate.webcaller.api.BoilerplateApi;
+import com.hpe.caf.boilerplate.webcaller.model.BoilerplateExpression;
+import com.hpe.caf.boilerplate.webcaller.model.Tag;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Responsible for deleting boilerplate expressions and tags that match the names of provided data.
+ */
+public class BoilerplateRemover {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BoilerplateRemover.class);
+
+    /**
+     * Removes expressions/tags that are retrievable using the BoilerplateApi that match the names of the provided expressions/tags.
+     * @param boilerplateApi API to use in retrieval and deletion of expressions/tags.
+     * @param expressionNamesToRemove Names of expressions. Any existing expressions that match these names will be removed.
+     * @param tagNamesToRemove Names of tags. Any existing tags that match these names will be removed.
+     * @throws ApiException If error occurs trying to communicate with boilerplate API.
+     */
+    public static void removeMatchingExpressionsAndTags(BoilerplateApi boilerplateApi, Collection<String> expressionNamesToRemove,
+                                                  Collection<String> tagNamesToRemove) throws ApiException {
+        removeMatchingTags(boilerplateApi, tagNamesToRemove);
+        removeMatchingExpressions(boilerplateApi, expressionNamesToRemove);
+    }
+
+    /**
+     * Removes expressions that are retrievable using the BoilerplateApi that match the names of the provided expressions.
+     * @param boilerplateApi API to use in retrieval and deletion of expressions/tags.
+     * @param expressionNamesToRemove Names of expressions. Any existing expressions that match these names will be removed.
+     * @throws ApiException If error occurs trying to communicate with boilerplate API.
+     */
+    public static void removeMatchingExpressions(BoilerplateApi boilerplateApi, Collection<String> expressionNamesToRemove)
+            throws ApiException {
+        int pageNum = 1;
+        final int pageSize = 100;
+        List<BoilerplateExpression> existingExpressions = new ArrayList<>();
+        while(true){
+            List<BoilerplateExpression> currentRetrievedExpressions = boilerplateApi.getExpressions(pageNum, pageSize);
+            existingExpressions.addAll(currentRetrievedExpressions);
+            if(currentRetrievedExpressions.size()!=pageSize){
+                break;
+            }
+            pageNum++;
+        }
+        //delete all expressions that have a name matching the provided expression names
+        for(BoilerplateExpression existingExpression: existingExpressions){
+            if(!expressionNamesToRemove.contains(existingExpression.getName())){
+                continue;
+            }
+            long expressionIdToDelete = existingExpression.getId();
+            String existingExpressionName = existingExpression.getName();
+            //check if this expression is in use by any tags
+            List<Tag> tagsUsingExpression = boilerplateApi.getTagsByExpression(expressionIdToDelete);
+            if(!tagsUsingExpression.isEmpty()){
+                LOGGER.warn("An expression with the name: '"+existingExpressionName+ "' is currently being used by the following tags: "+
+                        StringUtils.join(tagsUsingExpression, ", ")+". Due to this the existing expression will not be removed. Expression ID: "
+                        +expressionIdToDelete);
+                continue;
+            }
+            LOGGER.debug("Deleting expression with ID: "+expressionIdToDelete+" and name: "+existingExpressionName);
+            boilerplateApi.deleteExpression(expressionIdToDelete);
+            LOGGER.debug("Deleted expression with ID: "+expressionIdToDelete);
+        }
+    }
+
+    /**
+     * Removes tags that are retrievable using the BoilerplateApi that match the names of the provided tags.
+     * @param boilerplateApi API to use in retrieval and deletion of tags.
+     * @param tagNamesToRemove Names of tags. Any existing tags that match these names will be removed.
+     * @throws ApiException If error occurs trying to communicate with boilerplate API.
+     */
+    public static void removeMatchingTags(BoilerplateApi boilerplateApi, Collection<String> tagNamesToRemove) throws ApiException{
+        int pageNum = 1;
+        final int pageSize = 100;
+        List<Tag> existingTags = new ArrayList<>();
+        //retrieve all existing tags
+        while(true) {
+            List<Tag> currentRetrievedTags = boilerplateApi.getTags(pageNum, pageSize);
+            existingTags.addAll(currentRetrievedTags);
+            if(currentRetrievedTags.size()!=pageSize){
+                break;
+            }
+            pageNum++;
+        }
+        //delete all tags that have a name matching the provided tag names
+        for(Tag existingTag: existingTags){
+            String existingTagName = existingTag.getName();
+            if(!tagNamesToRemove.contains(existingTagName)){
+                continue;
+            }
+            long tagIdToDelete = existingTag.getId();
+            LOGGER.debug("Deleting tag with ID: "+tagIdToDelete+ " and name: "+existingTagName);
+            boilerplateApi.deleteTag(tagIdToDelete);
+            LOGGER.debug("Deleted tag with ID: "+tagIdToDelete);
+        }
+    }
+}

--- a/util-boilerplate-creation/src/main/java/com/hpe/caf/util/boilerplate/creation/BoilerplateRemover.java
+++ b/util-boilerplate-creation/src/main/java/com/hpe/caf/util/boilerplate/creation/BoilerplateRemover.java
@@ -76,7 +76,8 @@ public class BoilerplateRemover {
             List<Tag> tagsUsingExpression = boilerplateApi.getTagsByExpression(expressionIdToDelete);
             if(!tagsUsingExpression.isEmpty()){
                 LOGGER.warn("An expression with the name: '"+existingExpressionName+ "' is currently being used by the following tags: "+
-                        StringUtils.join(tagsUsingExpression, ", ")+". Due to this the existing expression will not be removed. Expression ID: "
+                        StringUtils.join(tagsUsingExpression, ", ")+
+                        ". Due to this the existing expression will not be removed. Expression ID: "
                         +expressionIdToDelete);
                 continue;
             }

--- a/util-boilerplate-creation/src/test/java/com/hpe/caf/util/boilerplate/creation/BoilerplateCreatorIT.java
+++ b/util-boilerplate-creation/src/test/java/com/hpe/caf/util/boilerplate/creation/BoilerplateCreatorIT.java
@@ -36,7 +36,7 @@ public class BoilerplateCreatorIT {
     private static final String cafBoilerplateApiUrl;
 
     static {
-        cafBoilerplateApiUrl = System.getProperty("cafBoilerplateApiUrl", "http://localhost:8080/boilerplateapi");
+        cafBoilerplateApiUrl = System.getProperty(Constants.Properties.BOILERPLATE_URL);
     }
 
     @Test(description = "Checks that expressions and tags are created with expected values.")
@@ -159,15 +159,18 @@ public class BoilerplateCreatorIT {
     }
 
     private void verifyCreatedExpression(CreationExpression expectedExpression, BoilerplateExpression createdExpression){
-        Assert.assertEquals(createdExpression.getDescription(), expectedExpression.getDescription(), "Description of created expression should be as expected.");
-        Assert.assertEquals(createdExpression.getExpression(), expectedExpression.getExpression(), "Expression on created expression should be as expected.");
-        Assert.assertEquals(createdExpression.getReplacementText(), expectedExpression.getReplacementText(), "Replacement text on created expression should be as expected.");
+        Assert.assertEquals(createdExpression.getDescription(), expectedExpression.getDescription(),
+                "Description of created expression should be as expected.");
+        Assert.assertEquals(createdExpression.getExpression(), expectedExpression.getExpression(),
+                "Expression on created expression should be as expected.");
+        Assert.assertEquals(createdExpression.getReplacementText(), expectedExpression.getReplacementText(),
+                "Replacement text on created expression should be as expected.");
     }
 
     private BoilerplateApi getBoilerplateApi(String projectId){
         ApiClient apiClient = new ApiClient();
         apiClient.setApiKey(projectId);
-        apiClient.setBasePath(System.getProperty(Constants.Properties.BOILERPLATE_URL));
+        apiClient.setBasePath(cafBoilerplateApiUrl);
         return new BoilerplateApi(apiClient);
     }
 

--- a/util-boilerplate-creation/src/test/java/com/hpe/caf/util/boilerplate/creation/BoilerplateCreatorIT.java
+++ b/util-boilerplate-creation/src/test/java/com/hpe/caf/util/boilerplate/creation/BoilerplateCreatorIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.util.boilerplate.creation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hpe.caf.boilerplate.webcaller.ApiClient;
+import com.hpe.caf.boilerplate.webcaller.ApiException;
+import com.hpe.caf.boilerplate.webcaller.api.BoilerplateApi;
+import com.hpe.caf.boilerplate.webcaller.model.BoilerplateExpression;
+import com.hpe.caf.boilerplate.webcaller.model.Tag;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Integration tests for boilerplate creation
+ */
+public class BoilerplateCreatorIT {
+    private static final String cafBoilerplateApiUrl;
+
+    static {
+        cafBoilerplateApiUrl = System.getProperty("cafBoilerplateApiUrl", "http://localhost:8080/boilerplateapi");
+    }
+
+    @Test(description = "Checks that expressions and tags are created with expected values.")
+    public void createExpressionsAndTagsTest() throws ApiException {
+        String testProjectId = UUID.randomUUID().toString();
+        Collection<CreationExpression> testExpressions = buildCreationExpressions(5, testProjectId);
+        Collection<Tag> testTags = buildTags(3, testProjectId, testExpressions.stream()
+                .map(ex -> ex.getTempId()).limit(3).collect(Collectors.toList()));
+        testTags.addAll(buildTags(2, testProjectId, testExpressions.stream()
+                .map(ex -> ex.getTempId()).skip(3).limit(2)
+                .collect(Collectors.toList())));
+
+        BoilerplateCreator bpCreator = new BoilerplateCreator();
+        bpCreator.createExpressionsAndTags(testProjectId, testExpressions, testTags);
+        BoilerplateApi boilerplateApi = getBoilerplateApi(testProjectId);
+        List<BoilerplateExpression> createdExpressions = boilerplateApi.getExpressions(1, 10);
+        verifyCreatedExpressions(testExpressions, createdExpressions);
+
+        List<Tag> createdTags = boilerplateApi.getTags(1, 10);
+        verifyCreatedTags(testTags, createdTags);
+    }
+
+    @Test(description = "Creates some expressions and tags then calls create again with the expectation that the first set of " +
+            "expressions and tags will be removed.")
+    public void removeExistingExpressionsAndTagsTest() throws ApiException, IOException {
+        String testProjectId = UUID.randomUUID().toString();
+        ObjectMapper mapper = new ObjectMapper();
+
+        Collection<CreationExpression> testExpressions = buildCreationExpressions(5, testProjectId);
+        Collection<Tag> testTags = buildTags(3, testProjectId, testExpressions.stream()
+                .map(ex -> ex.getTempId()).limit(3).collect(Collectors.toList()));
+        testTags.addAll(buildTags(2, testProjectId, testExpressions.stream()
+                .map(ex -> ex.getTempId()).skip(3).limit(2)
+                .collect(Collectors.toList())));
+
+        //creating a copy of the test tags as they will be modified during creation to have the actual IDs of created expressions
+        Collection<Tag> originalTestTags = mapper.readValue(mapper.writeValueAsBytes(testTags),
+                new TypeReference<List<Tag>>(){});
+
+        //create first set of expressions and tags
+        BoilerplateCreator bpCreator = new BoilerplateCreator();
+        bpCreator.createExpressionsAndTags(testProjectId, testExpressions, testTags);
+        BoilerplateApi boilerplateApi = getBoilerplateApi(testProjectId);
+        List<BoilerplateExpression> firstCreatedExpressions = boilerplateApi.getExpressions(1, 10);
+        verifyCreatedExpressions(testExpressions, firstCreatedExpressions);
+
+        List<Tag> firstCreatedTags = boilerplateApi.getTags(1, 10);
+        verifyCreatedTags(testTags, firstCreatedTags);
+
+        //record the IDs of those expressions and tags
+        List<Long> firstExpressionsIds = firstCreatedExpressions.stream().map(ex -> ex.getId()).collect(Collectors.toList());
+        List<Long> firstTagsIds = firstCreatedTags.stream().map(ta -> ta.getId()).collect(Collectors.toList());
+
+        //create second set of expressions and tags, expecting first set to be removed
+        bpCreator.createExpressionsAndTags(testProjectId, testExpressions, originalTestTags);
+
+        List<BoilerplateExpression> secondCreatedExpressions = boilerplateApi.getExpressions(1, 100);
+        //check that none of the expressions returned match the IDs of the first set
+        List<Long> curentExpressionIds = secondCreatedExpressions.stream()
+                .map(ex -> ex.getId()).collect(Collectors.toList());
+        for(Long firstExpressionId: firstExpressionsIds){
+            Assert.assertTrue(!curentExpressionIds.contains(firstExpressionId), "ID from first set of created expressions " +
+                    "should no longer be present.");
+        }
+
+        verifyCreatedExpressions(testExpressions, secondCreatedExpressions);
+
+        List<Tag> secondCreatedTags = boilerplateApi.getTags(1, 100);
+        List<Long> curentTagIds = secondCreatedTags.stream()
+                .map(ta -> ta.getId()).collect(Collectors.toList());
+        for(Long firstTagId: firstTagsIds){
+            Assert.assertTrue(!curentTagIds.contains(firstTagId), "ID from first set of created tags " +
+                    "should no longer be present.");
+        }
+        verifyCreatedTags(originalTestTags, secondCreatedTags);
+    }
+
+    private void verifyCreatedTags(Collection<Tag> expectedTags, List<Tag> createdTags){
+        Assert.assertEquals(
+                createdTags.size(),
+                expectedTags.size(),
+                "Number of created tags should be the same as the expected number.");
+        for(Tag expectedTag: expectedTags){
+            Optional<Tag> tagOptional = createdTags.stream().filter(ta -> ta.getName().equals(expectedTag.getName())).findFirst();
+            Assert.assertTrue(tagOptional.isPresent(), "Should have a created tag matching expected name.");
+            Tag createdTag = tagOptional.get();
+            verifyCreatedTag(expectedTag, createdTag);
+        }
+    }
+
+    private void verifyCreatedTag(Tag expectedTag, Tag createdTag){
+        Assert.assertEquals(createdTag.getDescription(), expectedTag.getDescription(),
+                "Description of created tag should be as expected.");
+        Assert.assertEquals(createdTag.getDefaultReplacementText(), expectedTag.getDefaultReplacementText(),
+                "Default replacement text on created tag should be as expected.");
+        List<Long> createdTagExpressionIds = createdTag.getBoilerplateExpressions();
+        List<Long> expectedTagExpressionIds = expectedTag.getBoilerplateExpressions();
+        Assert.assertEquals(createdTagExpressionIds.size(), expectedTagExpressionIds.size(),
+                "Expression IDs on created tag should be expected size.");
+        for(Long createdTagExpressionId: createdTagExpressionIds){
+            Assert.assertTrue(expectedTagExpressionIds.contains(createdTagExpressionId),
+                    "");
+        }
+
+    }
+
+    private void verifyCreatedExpressions(Collection<CreationExpression> expectedExpressions,
+                                          List<BoilerplateExpression> createdExpressions){
+        Assert.assertEquals(
+                createdExpressions.size(),
+                expectedExpressions.size(),
+                "Number of created expressions should be the same as the expected number.");
+        for(CreationExpression expectedExpression: expectedExpressions){
+            Optional<BoilerplateExpression> expressionOptional = createdExpressions.stream()
+                    .filter(ex -> ex.getName().equals(expectedExpression.getName())).findFirst();
+            Assert.assertTrue(expressionOptional.isPresent(), "Should have a created expression matching expected name.");
+            BoilerplateExpression createdExpression = expressionOptional.get();
+            verifyCreatedExpression(expectedExpression, createdExpression);
+        }
+    }
+
+    private void verifyCreatedExpression(CreationExpression expectedExpression, BoilerplateExpression createdExpression){
+        Assert.assertEquals(createdExpression.getDescription(), expectedExpression.getDescription(), "Description of created expression should be as expected.");
+        Assert.assertEquals(createdExpression.getExpression(), expectedExpression.getExpression(), "Expression on created expression should be as expected.");
+        Assert.assertEquals(createdExpression.getReplacementText(), expectedExpression.getReplacementText(), "Replacement text on created expression should be as expected.");
+    }
+
+    private BoilerplateApi getBoilerplateApi(String projectId){
+        ApiClient apiClient = new ApiClient();
+        apiClient.setApiKey(projectId);
+        apiClient.setBasePath(System.getProperty(Constants.Properties.BOILERPLATE_URL));
+        return new BoilerplateApi(apiClient);
+    }
+
+    private Collection<CreationExpression> buildCreationExpressions(int numToCreate, String projectId){
+        Collection<CreationExpression> expressions = new ArrayList<>();
+        for(long expressionTempId = 0; expressionTempId < numToCreate; expressionTempId++) {
+            CreationExpression expression = new CreationExpression();
+            expression.setTempId(expressionTempId);
+            expression.setName("Name_"+UUID.randomUUID().toString());
+            expression.setDescription("Desc_"+UUID.randomUUID().toString());
+            expression.setProjectId(projectId);
+            expression.setExpression("Expression_"+UUID.randomUUID().toString());
+            expression.setReplacementText("Replacement_text_"+UUID.randomUUID().toString());
+            expressions.add(expression);
+        }
+        return expressions;
+    }
+
+    private Collection<Tag> buildTags(int numToCreate, String projectId, List<Long> expressionsToUse){
+        Collection<Tag> tags = new ArrayList<>();
+        for(long tagIndex = 0; tagIndex < numToCreate; tagIndex++){
+            Tag tag = new Tag();
+            tag.setDescription("Desc_"+UUID.randomUUID().toString());
+            tag.setName("Name_"+UUID.randomUUID().toString());
+            tag.setProjectId(projectId);
+            tag.setBoilerplateExpressions(expressionsToUse);
+            tags.add(tag);
+        }
+        return tags;
+    }
+}

--- a/worker-boilerplate-container-fs/pom.xml
+++ b/worker-boilerplate-container-fs/pom.xml
@@ -241,7 +241,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
     <build>
@@ -263,7 +262,6 @@
 
                         <!-- boilerplate setup specific properties -->
                         <boilerplate.adminport>${boilerplate.adminport}</boilerplate.adminport>
-                        <docker.host.address>${docker.host.address}</docker.host.address>
                         <postgres.db.port>${postgres.db.port}</postgres.db.port>
                         <timeout.ms>${failsafe.timeout}</timeout.ms>
                     </systemPropertyVariables>


### PR DESCRIPTION
… expressions/tags if they have same name as those that are about to be created. Integration test for creation util added as part of this.

https://jira.autonomy.com/browse/CAF-3295