### PR TITLE
SCMOD-11754: Explicitly specify base image

### DIFF
--- a/worker-boilerplate-container-fs/pom.xml
+++ b/worker-boilerplate-container-fs/pom.xml
@@ -388,6 +388,7 @@
                             <alias>config</alias>
                             <name>${project.artifactId}-test-config:${project.version}</name>
                             <build>
+                                <from>${dockerHubPublic}/library/busybox:latest</from>
                                 <assembly>
                                     <basedir>/config</basedir>
                                     <inline>
@@ -492,6 +493,7 @@
                             <alias>util-data</alias>
                             <name>${project.artifactId}-test-data:${project.version}</name>
                             <build>
+                                <from>${dockerHubPublic}/library/busybox:latest</from>
                                 <assembly>
                                     <basedir>/util-data</basedir>
                                     <inline>

--- a/worker-boilerplate-container-fs/pom.xml
+++ b/worker-boilerplate-container-fs/pom.xml
@@ -391,6 +391,7 @@
                                 <from>${dockerHubPublic}/library/busybox:latest</from>
                                 <assembly>
                                     <basedir>/config</basedir>
+                                    <exportTargetDir>true</exportTargetDir>
                                     <inline>
                                         <fileSets>
                                             <fileSet>
@@ -496,6 +497,7 @@
                                 <from>${dockerHubPublic}/library/busybox:latest</from>
                                 <assembly>
                                     <basedir>/util-data</basedir>
+                                    <exportTargetDir>true</exportTargetDir>
                                     <inline>
                                         <fileSets>
                                             <fileSet>


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-11754

This change really should have been made as part of the [SCMOD-5156](https://portal.digitalsafe.net/browse/SCMOD-5156) changes.  Clearly cases where no base image was specified and the docker-maven-plugin defaulted to `busybox:latest` were overlooked.